### PR TITLE
Added form-control Bootstrap class, limit of 30 chars to field

### DIFF
--- a/omod/src/main/webapp/addCohortMemberAttribute.jsp
+++ b/omod/src/main/webapp/addCohortMemberAttribute.jsp
@@ -59,5 +59,7 @@
 </body>
 
 <script type="text/javascript">
-    $('#management-label-nav').addClass('active')
+    $('#management-label-nav').addClass('active');
+    $('#selectedvalue').addClass('form-control');
+    $('#selectedvalue').attr({ maxLength : 30 });
 </script>


### PR DESCRIPTION
Added _form-control_ Bootstrap class and added limit of 30 characters to field. Please see screenshot

![capture](https://cloud.githubusercontent.com/assets/11693595/19829411/30516030-9dfe-11e6-9eaf-25199bb38621.PNG)
